### PR TITLE
Make the plugin compatible with named trackers

### DIFF
--- a/sp-ga-plugin.js
+++ b/sp-ga-plugin.js
@@ -25,16 +25,14 @@ function SpGaPlugin(tracker, config) {
   var ga = getGA();
   var sendHitTask = 'sendHitTask';
 
-  ga(function(tracker) {
-    var originalSendHitTask = tracker.get(sendHitTask);
-    tracker.set(sendHitTask, function(model) {
-      var payload = model.get('hitPayload');
-      originalSendHitTask(model);
-      var request = new XMLHttpRequest();
-      request.open('POST', path, true);
-      request.setRequestHeader("Content-type", "text/plain; charset=UTF-8")
-      request.send(payload);
-    });
+  var originalSendHitTask = tracker.get(sendHitTask);
+  tracker.set(sendHitTask, function(model) {
+    var payload = model.get('hitPayload');
+    originalSendHitTask(model);
+    var request = new XMLHttpRequest();
+    request.open('POST', path, true);
+    request.setRequestHeader("Content-type", "text/plain; charset=UTF-8")
+    request.send(payload);
   });
 }
 

--- a/sp-ga-plugin.js
+++ b/sp-ga-plugin.js
@@ -22,7 +22,6 @@ function SpGaPlugin(tracker, config) {
   var version = 'v1';
   var path = this.endpoint + vendor + '/' + version;
 
-  var ga = getGA();
   var sendHitTask = 'sendHitTask';
 
   var originalSendHitTask = tracker.get(sendHitTask);


### PR DESCRIPTION
This PR fixes the integration so that it works with all analytics.js trackers - not just those created without a name.

The commit has detailed description of the rationale for the suggested change.